### PR TITLE
Added auth_basic off to catch-all nginx error page

### DIFF
--- a/_posts/2018-12-22-one-nginx-error-page-to-rule-them-all.md
+++ b/_posts/2018-12-22-one-nginx-error-page-to-rule-them-all.md
@@ -20,6 +20,7 @@ error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 4
 location = /error.html {
   ssi on;
   internal;
+  auth_basic off;
   root /var/www/default;
 }
 ```


### PR DESCRIPTION
Without `auth_basic off` the error page won't be used for 401 pages.