### PR TITLE
Update 2017-07-10-make-async-await-work-in-promises.md

### DIFF
--- a/_posts/2017-07-10-make-async-await-work-in-promises.md
+++ b/_posts/2017-07-10-make-async-await-work-in-promises.md
@@ -35,9 +35,16 @@ But still no luck, then I realised I didn't have an async function. The arrow fu
 
 ```js
 function returnSomething(name) {
-  return new Promise(async (resolve, reject) => { // <--- this line
-    const somethingElse = await returnSomethingElse();
-    return resolve(somethingElse);
+  return new Promise((resolve, reject) => {
+    (async () => {
+      try {
+        const somethingElse = await returnSomethingElse();
+        resolve(somethingElse);
+      } catch (err) {
+        reject(err);
+      }
+    })();
   });
+}
 }
 ```


### PR DESCRIPTION
The Promise executor function should not be async. Though this works, if the executor functions throws an error, the error will be lost and wont cause newly created promise function to reject. This will make it difficult to debug and handle some errors