### PR TITLE
Update 2018-12-29-log-cronjob-output-to-syslog-in-ubuntu.md

### DIFF
--- a/_posts/2018-12-29-log-cronjob-output-to-syslog-in-ubuntu.md
+++ b/_posts/2018-12-29-log-cronjob-output-to-syslog-in-ubuntu.md
@@ -14,7 +14,7 @@ Dec 29 12:00:00 server CRON[1009]: (CRON) info (No MTA installed, discarding out
 _No MTA installed, discarding output_ is basically saying that it can't log because there is no email client. Default logs of cronjobs are send to an email client. This is not something I want so I change my crontab `crontab -e` to this:
 
 ```
-*/10 * * * * /home/user/do-something.sh 2>&1 | /usr/bin/logger -t BACKUP
+*/10 * * * * /home/user/do-something.sh 2>&1 | /usr/bin/logger -t CRON
 ```
 
 Explanation
@@ -22,6 +22,6 @@ Explanation
 - `*/10 * * * *` Runs the script every 10 minutes
 - `/home/user/do-something.sh` is the script being exucted
 - `2>&1` forwards the error to standard output
-- `| /usr/bin/logger -t BACKUP` forwards (pipes) stardard output to syslog with the name `BACKUP`
+- `| /usr/bin/logger -t CRON` forwards (pipes) stardard output to syslog with the name `CRON`
 
-If you use the name `BACKUP` you can search your logs like this `cat /var/log/syslog | grep BACKUP` and you have all output of the `/home/user/do-something.sh` script.
+If you use the name `CRON` you can search your logs like this `cat /var/log/syslog | grep CRON` and you have all output of the `/home/user/do-something.sh` script.


### PR DESCRIPTION
change label from nondescript "BACKUP" to descriptive "CRON"